### PR TITLE
Docs: Add RST directives to c-api/intro#Include_Files

### DIFF
--- a/Doc/c-api/intro.rst
+++ b/Doc/c-api/intro.rst
@@ -46,7 +46,9 @@ Include Files
 =============
 
 All function, type and macro definitions needed to use the Python/C API are
-included in your code by the following line::
+included in your code by the following line:
+
+.. code:: c
 
    #define PY_SSIZE_T_CLEAN
    #include <Python.h>
@@ -69,10 +71,12 @@ standard headers) have one of the prefixes ``Py`` or ``_Py``.  Names beginning
 with ``_Py`` are for internal use by the Python implementation and should not be
 used by extension writers. Structure member names do not have a reserved prefix.
 
-**Important:** user code should never define names that begin with ``Py`` or
-``_Py``.  This confuses the reader, and jeopardizes the portability of the user
-code to future Python versions, which may define additional names beginning with
-one of these prefixes.
+.. important:: 
+
+   User code should never define names that begin with ``Py`` or
+   ``_Py``.  This confuses the reader, and jeopardizes the portability of the user
+   code to future Python versions, which may define additional names beginning with
+   one of these prefixes.
 
 The header files are typically installed with Python.  On Unix, these  are
 located in the directories :file:`{prefix}/include/pythonversion/` and
@@ -90,9 +94,11 @@ multi-platform builds since the platform independent headers under
 :envvar:`prefix` include the platform specific headers from
 :envvar:`exec_prefix`.
 
-C++ users should note that though the API is defined entirely using C, the
-header files do properly declare the entry points to be ``extern "C"``, so there
-is no need to do anything special to use the API from C++.
+.. note::
+
+   C++ users should note that although the API is defined entirely using C, the
+   header files properly declare the entry points to be ``extern "C"``. As a result,
+   there is no need to do anything special to use the API from C++.
 
 
 Useful macros


### PR DESCRIPTION
Adds the following directives to the "Include Files" section: code c, important, and note. Also improves the phrasing in the section where a note was added, on lines 99-101.

Since this change is quite minor and doesn't affect the actual message conveyed, I decided to go without creating an issue for it. It's mostly formatting related and an improvement to the phrasing (splits a run-on sentence into two individual ones).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
