### PR TITLE
Docs: Fix argument name for PyLong_FromLong()

### DIFF
--- a/Doc/c-api/long.rst
+++ b/Doc/c-api/long.rst
@@ -36,9 +36,9 @@ distinguished from a number.  Use :c:func:`PyErr_Occurred` to disambiguate.
    :c:type:`PyLongObject`.
 
 
-.. c:function:: PyObject* PyLong_FromLong(long v)
+.. c:function:: PyObject* PyLong_FromLong(long ival)
 
-   Return a new :c:type:`PyLongObject` object from *v*, or *NULL* on failure.
+   Return a new :c:type:`PyLongObject` object from *ival*, or *NULL* on failure.
 
    The current implementation keeps an array of integer objects for all integers
    between ``-5`` and ``256``, when you create an int in that range you actually


### PR DESCRIPTION
In C-API docs, the first positional argument's name for the function `PyLong_FromLong()` is shown as `v`, but in the [function's definition](https://github.com/python/cpython/blob/e8692818afd731c1b7e925c626ac8200b1f1c31e/Objects/longobject.c#L310), it's `ival`. Noticed this while reviewing a PR which proposed to remove the last sentence from the summary of this function. 

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
